### PR TITLE
Update Tempo to 1.5.0

### DIFF
--- a/packages/checks/default.nix
+++ b/packages/checks/default.nix
@@ -8,5 +8,8 @@
     patroni = pkgs.callPackage ./patroni.nix {
       patroniModule = self.nixosModules.patroni;
     };
+    tempo = pkgs.callPackage ./tempo.nix {
+      inherit (self'.packages) tempo;
+    };
   };
 }

--- a/packages/checks/tempo.nix
+++ b/packages/checks/tempo.nix
@@ -1,0 +1,78 @@
+{ nixosTest, tempo, writeText }:
+
+nixosTest {
+  name = "tempo";
+  nodes.machine = let
+    dataDir = "/var/lib/tempo";
+    tempoConfig = {
+      search_enabled = true;
+      metrics_generator_enabled = true;
+      server = {
+        http_listen_address = "127.0.0.1";
+        http_listen_port = 8888;
+      };
+      ingester = {
+        trace_idle_period = "30s";
+        max_block_bytes = 1000000;
+        max_block_duration = "5m";
+      };
+      compactor = {
+        compaction = {
+          compaction_window = "1h";
+          max_block_bytes = 100000000;
+          compacted_block_retention = "10m";
+        };
+      };
+      storage.trace = {
+        backend = "local";
+        block = {
+          bloom_filter_false_positive = 0.05;
+          index_downsample_bytes = 1000;
+          encoding = "zstd";
+        };
+        wal.path = "${dataDir}/wal";
+        wal.encoding = "snappy";
+        local.path = "${dataDir}/blocks";
+        pool = {
+          max_workers = 16;
+          queue_depth = 1000;
+        };
+      };
+      metrics_generator = {
+        registry.external_labels = {
+          source = "tempo";
+        };
+        storage = {
+          path = "${dataDir}/generator/wal";
+        };
+      };
+      overrides.metrics_generator_processors = [
+        "service-graphs"
+        "span-metrics"
+      ];
+    };
+  in {
+    users.users.tempo = {
+      isSystemUser = true;
+      group = "tempo";
+      home = dataDir;
+      createHome = true;
+    };
+
+    users.groups.tempo = {};
+    systemd.services.tempo = {
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        User = "tempo";
+        Group = "tempo";
+        ExecStart = "${tempo}/bin/tempo -config.file=${writeText "tempo.yaml" (builtins.toJSON tempoConfig)}";
+        PrivateTmp = true;
+      };
+    };
+  };
+  testScript = ''
+    machine.wait_for_unit("tempo.service")
+    machine.wait_for_open_port("8888")
+    machine.succeed("curl --fail http://127.0.0.1:8888/status/version")
+  '';
+}

--- a/packages/patched-derivations.nix
+++ b/packages/patched-derivations.nix
@@ -48,7 +48,7 @@ super: rec {
 
   prometheus-jitsi-exporter = patch super.prometheus-jitsi-exporter "patches/base/prometheus-jitsi-exporter";
 
-  tempo = super.tempo.overrideAttrs (_: {
+  tempo = (super.tempo.override { buildGoModule = super.buildGo118Module; }).overrideAttrs (_: {
     version = builtins.substring 1 (-1) pins.tempo.version;
     src = super.npins.mkSource pins.tempo;
     subPackages = [ "cmd/tempo" ];

--- a/packages/sources/sources.json
+++ b/packages/sources/sources.json
@@ -63,10 +63,10 @@
       },
       "pre_releases": false,
       "version_upper_bound": null,
-      "version": "v1.4.1",
-      "revision": "561f92b3fe2384126708a06e4f1db422d62db986",
-      "url": "https://api.github.com/repos/grafana/tempo/tarball/v1.4.1",
-      "hash": "0r4i6v5g0qisyx1gha87n67zcgm64p0v548q9z75hw55qkvzw8m6"
+      "version": "v1.5.0",
+      "revision": "1a97bea16259be7863dda77e1a6df09eb048b202",
+      "url": "https://api.github.com/repos/grafana/tempo/tarball/v1.5.0",
+      "hash": "0hvpp4kd59p22p25ngp2lrm6f2va36q0j8xx4k223n3hnhawkmf3"
     },
     "uptime-kuma": {
       "type": "GitRelease",

--- a/packages/system-filter.nix
+++ b/packages/system-filter.nix
@@ -15,5 +15,6 @@
   checks = {
     keycloak = [ "x86_64-linux" ];
     patroni = [ "x86_64-linux" ];
+    tempo = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
Tempo now requires Go 1.18 so use `buildGo118Module` to build it.

Includes a simple NixOS test